### PR TITLE
ci: add manifest inspection step for GHCR images

### DIFF
--- a/.github/workflows/cd-image.yml
+++ b/.github/workflows/cd-image.yml
@@ -54,3 +54,11 @@ jobs:
             ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:latest
             ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.run_tag }}
             ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.short_sha }}
+
+
+      - name: Show pushed manifests
+        run: |
+          echo "short: ${{ steps.meta.outputs.short_sha }}"
+          echo "run:   ${{ steps.meta.outputs.run_tag }}"
+          docker buildx imagetools inspect ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.short_sha }} || true
+          docker buildx imagetools inspect ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.run_tag }} || true

--- a/.github/workflows/cd-image.yml
+++ b/.github/workflows/cd-image.yml
@@ -13,9 +13,6 @@ jobs:
   docker-publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: java-project/taskvault
 
     steps:
       - name: Checkout source at the commit that triggered CI
@@ -25,7 +22,7 @@ jobs:
 
       - name: Prepare lowercase owner for GHCR
         id: owner
-        run: echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+        run: echo "owner_lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
       - name: Compute SHORT_SHA and RUN_TAG
         id: meta
@@ -33,6 +30,12 @@ jobs:
           short_sha="${{ github.event.workflow_run.head_sha }}"
           echo "short_sha=$(echo $short_sha | cut -c1-7)" >> "$GITHUB_OUTPUT"
           echo "run_tag=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Debug — show tree where Dockerfile lives
+        run: |
+          ls -la
+          echo "---"
+          ls -la java-project/taskvault
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -44,17 +47,10 @@ jobs:
       - name: Build & Push (latest + run number + short sha)
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: Dockerfile
+          context: ./java-project/taskvault
+          file: ./java-project/taskvault/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ steps.owner.outputs.lc }}/taskvault-api:latest
-            ghcr.io/${{ steps.owner.outputs.lc }}/taskvault-api:${{ steps.meta.outputs.run_tag }}
-            ghcr.io/${{ steps.owner.outputs.lc }}/taskvault-api:${{ steps.meta.outputs.short_sha }}
-
-      - name: Show pushed manifest(s)
-        run: |
-          echo "short: ${{ steps.meta.outputs.short_sha }}"
-          echo "run:   ${{ steps.meta.outputs.run_tag }}"
-          docker buildx imagetools inspect ghcr.io/${{ steps.owner.outputs.lc }}/taskvault-api:${{ steps.meta.outputs.short_sha }} || true
-          docker buildx imagetools inspect ghcr.io/${{ steps.owner.outputs.lc }}/taskvault-api:${{ steps.meta.outputs.run_tag }} || true
+            ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:latest
+            ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.run_tag }}
+            ghcr.io/${{ steps.owner.outputs.owner_lc }}/taskvault-api:${{ steps.meta.outputs.short_sha }}


### PR DESCRIPTION
### Änderungen
- Nach dem Build & Push in `cd-image.yml` wird nun ein Schritt `Show pushed manifests` ausgeführt.
- Dieser prüft die gepushten Tags (`short sha` + `run number`) direkt im GHCR Registry.
- Damit lässt sich sofort validieren, ob Images korrekt veröffentlicht wurden.

### Motivation
In vorherigen Runs kam es zu "manifest unknown"-Fehlern im CD-Workflow.  
Mit diesem Debug-Schritt können wir nachvollziehen, ob und wann die Images tatsächlich gepusht wurden.

### Erwartetes Ergebnis
- Publish-Workflow zeigt nach dem Push die verfügbaren Image-Tags an.
- CD-Workflow kann zuverlässig auf die Images zugreifen.