### PR TITLE
ci: add concurrency groups for CI, publish and deploy

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -1,11 +1,13 @@
 name: Taskvault CD (Compose on Runner)
 
 on:
-  # ⚠️ WICHTIG: CD startet NACH erfolgreichem Image-Publish
+  # WICHTIG: CD startet ERST NACH erfolgreichem Image-Publish
   workflow_run:
     workflows: ["Publish Docker image (GHCR)"]
     types: [completed]
-
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/cd-image.yml
+++ b/.github/workflows/cd-image.yml
@@ -4,7 +4,9 @@ on:
   workflow_run:
     workflows: ["Taskvault CI Build & Test"]
     types: [completed]
-
+concurrency:
+  group: publish-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches: [main, develop, feature/*]
   workflow_dispatch:
-
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -16,15 +18,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-
       - name: Setup Java 17 (Temurin)
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-
       - name: Build and Test (Maven)
         run: mvn -B -ntp -DpersistenceUnit=taskvault-unit-test clean verify
       - name: Upload API Test Reports


### PR DESCRIPTION
- Prevent parallel-/dead/-Zombie runs across the pipeline
- CI: cancel older runs per branch (group: ci-${{ github.ref }})
- Publish: only latest per source branch (group: publish-${{ head_branch }})
- Deploy: only latest per source branch (group: deploy-${{ head_branch }})
- Optional timeouts can be added later if needed